### PR TITLE
Fix tr spectra

### DIFF
--- a/coreloop/spectra_in.c
+++ b/coreloop/spectra_in.c
@@ -91,16 +91,15 @@ bool transfer_from_df()
             }
             mask <<= 1;
         }
+        transfer_time_resolved_from_df();
         avg_counter++;
     }
-    transfer_time_resolved_from_df();
 
     return accept;
 }
 
 bool transfer_time_resolved_from_df()
 {
- 
     if (state.seq.tr_stop <= state.seq.tr_start) {
         return false;
     }

--- a/coreloop/spectra_in.c
+++ b/coreloop/spectra_in.c
@@ -91,9 +91,10 @@ bool transfer_from_df()
             }
             mask <<= 1;
         }
-        transfer_time_resolved_from_df();
-        avg_counter++;
-    }
+    } // if (accept)
+
+    transfer_time_resolved_from_df();
+    avg_counter++;
 
     return accept;
 }

--- a/coreloop/spectra_out.c
+++ b/coreloop/spectra_out.c
@@ -82,6 +82,11 @@ void dispatch_tr_data() {
     const uint8_t spec_idx = state.cdi_dispatch.tr_count;
     // length of individual chunk we need to copy (corresponds to fixed avg_counter value)
     const uint32_t single_len = get_tr_length(&state);
+
+    // nothing to do: return early, do not send header and no data
+    if (single_len == 0)
+        return;
+
     const size_t single_size = single_len * sizeof(uint16_t);
     uint16_t Navg2 = get_Navg2(&state);
 

--- a/coreloop/spectra_out.c
+++ b/coreloop/spectra_out.c
@@ -109,15 +109,20 @@ void dispatch_tr_data() {
     char* crc_input = cdi_ptr;
 
     // copy chunks of time resolved spectra
-    uint16_t* tr_ptr = tr_spectra_read_buffer(tick_tock) + spec_idx * single_len;
+    uint16_t* tr_ptr = (uint16_t*)tr_spectra_read_buffer(tick_tock) + spec_idx * single_len;
+
     for(int i = 0; i < Navg2; ++i) {
         // NB: types of pointers are different, but that is fine, memcpy takes void*
         // and operates byte-wise
         memcpy(cdi_ptr, tr_ptr, single_size);
         cdi_ptr += single_size;
         // zero copied chunk in tick/tock buffer
-        memset(tr_ptr, 0, single_size);
         tr_ptr += NSPECTRA * single_len;
+    }
+
+    // we copied last product, zero TR buffer
+    if (spec_idx == NSPECTRA - 1) {
+        memset(tr_spectra_read_buffer(tick_tock), 0, NSPECTRA * Navg2 *single_size);
     }
 
     // done copying data, can compute CRC now


### PR DESCRIPTION
Fix bugs in spectra_in and spectra_out:
- in spectra_in, transfer of TR spectra happened regardless of accept value and used the wrong (off by 1) avg_counter
- in spectra_out, pointer to CDI buffer was not advanced and CRC was computed with the wrong pointer