### PR TITLE
An/fix reject 2

### DIFF
--- a/coreloop/commanding.c
+++ b/coreloop/commanding.c
@@ -13,7 +13,6 @@ void cdi_not_implemented(const char *msg)
 {
     debug_print("\r\nCDI command not implemented: ");
     debug_print(msg);
-    return;
 }
 
 void cmd_soft_reset(uint8_t arg_low, struct core_state* state)
@@ -374,7 +373,6 @@ bool process_cdi(struct core_state* state)
                     state->base.errors |= CDI_COMMAND_BAD_ARGS;
                     break;
             }
-                spec_set_ADC_ramp(arg_low);
             break;
 
 

--- a/coreloop/high_prec_avg.h
+++ b/coreloop/high_prec_avg.h
@@ -41,18 +41,15 @@ static inline int32_t get_averaged_value_int40(const uint32_t* buf, int offset, 
     } else if (Navgf == 2) {
         result = get_packed_value(buf, buf_high, offset + 2*i);
         result += get_packed_value(buf, buf_high, offset + 2*i + 1);
-        shift_by += 1;
     } else if (Navgf == 3) {
         result = get_packed_value(buf, buf_high, offset + 4*i);
         result += get_packed_value(buf, buf_high, offset + 4*i + 1);
         result += get_packed_value(buf, buf_high, offset + 4*i + 2);
-        shift_by += 2;
     } else if (Navgf == 4) {
         result = get_packed_value(buf, buf_high, offset + 4*i);
         result += get_packed_value(buf, buf_high, offset + 4*i + 1);
         result += get_packed_value(buf, buf_high, offset + 4*i + 2);
         result += get_packed_value(buf, buf_high, offset + 4*i + 3);
-        shift_by += 2;
     }
 
     return (int32_t)(result >> shift_by);
@@ -61,7 +58,7 @@ static inline int32_t get_averaged_value_int40(const uint32_t* buf, int offset, 
 
 #endif
 
-static inline int32_t get_averaged_value_int32(const int32_t* buf, int offset, int i, int Navgf, int shift_by)
+static inline int32_t get_averaged_value_int32(const int32_t* buf, int offset, int i, int Navgf)
 {
     int32_t result;
 
@@ -73,13 +70,13 @@ static inline int32_t get_averaged_value_int32(const int32_t* buf, int offset, i
         result += buf[offset + 2*i + 1] / 2;
     } else if (Navgf == 3) {
         result = buf[offset + 4*i] / 4;
-        result = buf[offset + 4*i + 1] / 4;
-        result = buf[offset + 4*i + 2] / 4;
+        result += buf[offset + 4*i + 1] / 4;
+        result += buf[offset + 4*i + 2] / 4;
     } else if (Navgf == 4) {
         result = buf[offset + 4*i] / 4;
-        result = buf[offset + 4*i + 1] / 4;
-        result = buf[offset + 4*i + 2] / 4;
-        result = buf[offset + 4*i + 3] / 4;
+        result += buf[offset + 4*i + 1] / 4;
+        result += buf[offset + 4*i + 2] / 4;
+        result += buf[offset + 4*i + 3] / 4;
     }
 
     return result;
@@ -97,18 +94,15 @@ static inline int32_t get_averaged_value_float(const void* _buf, int offset, int
     } else if (Navgf == 2) {
         result = (int64_t)buf[offset + 2 * i];
         result += (int64_t)buf[offset + 2 * i + 1];
-        shift_by += 1;
     } else if (Navgf == 3) {
         result = (int64_t)buf[offset + 4 * i];
         result += (int64_t)buf[offset + 4 * i + 1];
         result += (int64_t)buf[offset + 4 * i + 2];
-        shift_by += 2;
     } else if (Navgf == 4) {
         result = (int64_t)buf[offset + 4 * i];
         result += (int64_t)buf[offset + 4 * i + 1];
         result += (int64_t)buf[offset + 4 * i + 2];
         result += (int64_t)buf[offset + 4 * i + 3];
-        shift_by += 2;
     }
 
     return (int32_t)(result >> shift_by);
@@ -117,7 +111,8 @@ static inline int32_t get_averaged_value_float(const void* _buf, int offset, int
 static inline int32_t get_averaged_value(const void* buf, int offset, int i, int Navgf, int shift_by, uint8_t averaging_mode, const uint32_t* buf_high)
 {
     if (averaging_mode == AVG_INT32) {
-        return get_averaged_value_int32(buf, offset, i, Navgf, shift_by);
+        // in int32 mode
+        return get_averaged_value_int32(buf, offset, i, Navgf);
     } else if (averaging_mode == AVG_INT_40_BITS) {
         return get_averaged_value_int40(buf, offset, i, Navgf, shift_by, buf_high);
     } else if (averaging_mode == AVG_FLOAT) {

--- a/coreloop/high_prec_avg.h
+++ b/coreloop/high_prec_avg.h
@@ -1,11 +1,8 @@
 #ifndef LN_CORELOOP_HIGH_PREC_AVG_H
 #define LN_CORELOOP_HIGH_PREC_AVG_H
 
-#include <stdio.h>
 #include <string.h>
-#include "spectrometer_interface.h"
 #include "core_loop.h"
-#include "LuSEE_IO.h"
 
 /* Helper functions to work with packed high bits */
 static inline int8_t get_high_bits(const uint32_t* buf_high, int total_idx) {
@@ -54,9 +51,6 @@ static inline int32_t get_averaged_value_int40(const uint32_t* buf, int offset, 
 
     return (int32_t)(result >> shift_by);
 }
-
-
-#endif
 
 static inline int32_t get_averaged_value_int32(const int32_t* buf, int offset, int i, int Navgf)
 {
@@ -119,3 +113,5 @@ static inline int32_t get_averaged_value(const void* buf, int offset, int i, int
         return get_averaged_value_float(buf, offset, i, Navgf, shift_by);
     }
 }
+
+#endif

--- a/coreloop/spectra_in.c
+++ b/coreloop/spectra_in.c
@@ -206,6 +206,7 @@ bool transfer_from_df(struct core_state* state)
     const uint32_t* ddr_ptr_prev_high = spectra_read_buffer_high(state->tick_tock);
     uint16_t mask = 1;
     bool accept = true;
+
     //debug_print("Processing spectra...\n\r");
     if ((state->base.reject_ratio>0) && (state->base.weight>(get_Navg2(state)/2))) {
         uint32_t bad = 0;
@@ -217,10 +218,11 @@ bool transfer_from_df(struct core_state* state)
 
             if (state->base.corr_products_mask & mask) {                
                 for (int total_idx = offset; total_idx < offset + NCHANNELS; total_idx++) {
-                    uint32_t bad_entry =is_bad(*df_ptr, ddr_ptr_prev, ddr_ptr_prev_high, total_idx, state->base.weight, state->base.reject_ratio, state->base.Navg2_shift, state->base.averaging_mode, all_prev_accepted);
                     bad += is_bad(*df_ptr, ddr_ptr_prev, ddr_ptr_prev_high, total_idx, state->base.weight, state->base.reject_ratio, state->base.Navg2_shift, state->base.averaging_mode, all_prev_accepted);
                     df_ptr++;
                 }
+
+                // print(stderr, "spectrum:%d, bad: %d, maxbad=%d, reject_ration=%d\n", sp, bad, state->base.reject_maxbad, state->base.reject_ratio);
 
             } else {
                 df_ptr += NCHANNELS;

--- a/coreloop/spectra_in.c
+++ b/coreloop/spectra_in.c
@@ -9,7 +9,7 @@
 #include "LuSEE_IO.h"
 #include "high_prec_avg.h"
 
-#define CORELOOP_SPECTRA_IN_AVOID_DIV_IN_BAD
+// #define CORELOOP_SPECTRA_IN_AVOID_DIV_IN_BAD
 
 
 static inline int32_t get_with_zeros(int32_t val, uint8_t *min, uint8_t *max) {

--- a/coreloop/spectra_in.c
+++ b/coreloop/spectra_in.c
@@ -30,6 +30,11 @@ bool transfer_grimm_from_df(struct core_state* state);
 
 static inline uint32_t is_bad_int32(const int32_t curr_val, const void* ddr_ptr_prev, int total_idx, uint8_t weight, uint8_t reject_ratio, uint8_t Navg2_shift, bool all_prev_accepted)
 {
+    // too small values should be ignored: we divide by Navg2 _before_ accumulating
+    // so for a small bin many values can become 0
+    if (curr_val < reject_ratio * (1 << Navg2_shift))
+        return 0;
+
     int32_t prev_val = ((int32_t*)ddr_ptr_prev)[total_idx];
     if (!all_prev_accepted) {
         // we may lose some precision here, but it's cheaper than int64

--- a/coreloop/spectra_out.c
+++ b/coreloop/spectra_out.c
@@ -106,7 +106,7 @@ static void dispatch_data(struct core_state* state) {
         int32_t vals_in[4];
         uint16_t vals_out[5];
 
-        for (int i = 0; i < state->cdi_dispatch.Nfreq; i++) {
+        for (int i = 0; i <= state->cdi_dispatch.Nfreq; i++) {
             if (i > 0 && i % 4 == 0) {
                 // we accumulated 4 values in vals_in;
                 // now we compress them into vals_out and copy to CDI buffer
@@ -114,7 +114,9 @@ static void dispatch_data(struct core_state* state) {
                 memcpy(data_ptr, vals_out, sizeof vals_out);
                 data_ptr += sizeof vals_out;
             }
-            vals_in[i % 4] = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, state->base.Navg2_shift, state->base.averaging_mode, ddr_ptr_high);
+            if (i != state->cdi_dispatch.Nfreq) {
+                vals_in[i % 4] = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, state->base.Navg2_shift, state->base.averaging_mode, ddr_ptr_high);
+            }
         }
     } else {
         cdi_not_implemented("data format not supported");

--- a/coreloop/spectra_out.c
+++ b/coreloop/spectra_out.c
@@ -3,11 +3,9 @@
 #include <stdint.h>
 
 #include "core_loop.h"
-#include "lusee_commands.h"
 #include "spectrometer_interface.h"
 #include "cdi_interface.h"
 #include "lusee_appIds.h"
-#include "flash_interface.h"
 #include "LuSEE_IO.h"
 #include "high_prec_avg.h"
 
@@ -126,7 +124,9 @@ static void dispatch_data(struct core_state* state) {
     // against this. Instead, we will zero it in df_transfer
     //memset(ddr_ptr, 0, state.state->cdi_dispatch.Nfreq * sizeof(uint32_t));
 
-    *crc_ptr = CRC(data_start_ptr, data_size);
+    uint32_t crc_value = CRC(data_start_ptr, data_size);
+    memcpy(crc_ptr, &crc_value, sizeof crc_value);
+
     cdi_dispatch_uC(&(state->cdi_stats),state->cdi_dispatch.appId, packet_size);
 }
 

--- a/coreloop/spectra_out.c
+++ b/coreloop/spectra_out.c
@@ -28,14 +28,34 @@ void send_metadata_packet(struct core_state* state) {
     reset_errormasks(state);
 }
 
-// write packet id to the beginning of the buffer
-// make crc_ptr to point to the next int32_t after packet_id
-// make data_ptr to point to the data buffer (after CRC)
-void write_packet_id(uint32_t packet_id, char** data_ptr, char** crc_ptr)
-{
-    char *cdi_ptr = (char*)TLM_BUF;
+static int get_shift(struct core_state* state) {
+    if (state->base.Navgf == 1)
+        return state->base.Navg2_shift;
+    if (state->base.Navgf == 2)
+        return state->base.Navg2_shift + 1;
+    if (state->base.Navgf == 3)
+        return state->base.Navg2_shift + 2;
+    if (state->base.Navgf == 4)
+        return state->base.Navg2_shift + 2;
+
+    // should never get there
+    debug_print("E");
+    return state->base.Navg2_shift;
+}
+
+static void prepare_spectrum_packet(struct core_state* state, int32_t* data_size, int32_t* packet_size, char** data_ptr, char** crc_ptr) {
+    // compute sizes
+    uint8_t format = state->cdi_dispatch.format;
+    if (state->cdi_dispatch.format == OUTPUT_32BIT) {
+        *data_size = state->cdi_dispatch.Nfreq * sizeof(uint32_t);
+    } else if (format == OUTPUT_16BIT_4_TO_5 || format == OUTPUT_16BIT_10_PLUS_6 || format == OUTPUT_16BIT_FLOAT1 || format == OUTPUT_16BIT_SHARED_LZ) {
+        *data_size = state->cdi_dispatch.Nfreq * sizeof(uint16_t);
+    }
+
+    char *cdi_ptr = TLM_BUF;
 
     // write packet_id
+    uint32_t packet_id = state->cdi_dispatch.packet_id;
     memcpy(cdi_ptr, &packet_id, sizeof packet_id);
     cdi_ptr += sizeof packet_id;
 
@@ -43,126 +63,74 @@ void write_packet_id(uint32_t packet_id, char** data_ptr, char** crc_ptr)
     *crc_ptr = cdi_ptr;
     cdi_ptr += sizeof(CRC(cdi_ptr, 1));
 
-    // save pointer to the beginning of actual data, to compute its CRC
+    *packet_size = (*data_size) + sizeof(packet_id) + sizeof(CRC(cdi_ptr, 1));
+
+    // save pointer to the beginning of actual data
     *data_ptr = cdi_ptr;
 }
 
-void dispatch_32bit_data(struct core_state* state) {
+
+static void dispatch_data(struct core_state* state) {
     // if we are in tick, we are copyng over TOCK, otherwise TICK !!
     const void *ddr_ptr = spectra_read_buffer(state->tick_tock);
     const uint32_t* ddr_ptr_high = spectra_read_buffer_high(state->tick_tock);
     int offset = state->cdi_dispatch.prod_count * NCHANNELS;
-    int32_t *cdi_ptr = (int32_t *)TLM_BUF;
-    int32_t *crc_ptr;
 
-    *cdi_ptr = (int32_t)(state->cdi_dispatch.packet_id);
-    cdi_ptr++;
-    crc_ptr = cdi_ptr;
-    cdi_ptr++;
-    uint32_t data_size = state->cdi_dispatch.Nfreq*sizeof(int32_t);
-    uint32_t packet_size = data_size+2*sizeof(int32_t);
+    int32_t data_size, packet_size;
+    char *data_ptr, *crc_ptr;
+
+    prepare_spectrum_packet(state, &data_size, &packet_size, &data_ptr, &crc_ptr);
+
+    const char* const data_start_ptr = data_ptr;
+
     wait_for_cdi_ready();
 
-    for (int i = 0; i < state->cdi_dispatch.Nfreq; i++) {
-        cdi_ptr[i] = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, state->base.Navg2_shift, state->base.averaging_mode, ddr_ptr_high);
+    int shift_by = get_shift(state);
+
+    if (state->cdi_dispatch.format == OUTPUT_32BIT) {
+        for (int i = 0; i < state->cdi_dispatch.Nfreq; i++) {
+            int32_t val = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, shift_by, state->base.averaging_mode, ddr_ptr_high);
+            memcpy(data_ptr, &val, sizeof val);
+            data_ptr += sizeof val;
+        }
+    } else if (state->cdi_dispatch.format == OUTPUT_16BIT_10_PLUS_6) {
+        uint16_t val_out;
+        int32_t val_in;
+
+        for (int i = 0; i < state->cdi_dispatch.Nfreq; i++) {
+            val_in = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, state->base.Navg2_shift, state->base.averaging_mode, ddr_ptr_high);
+            val_out = encode_10plus6(val_in);
+            memcpy(data_ptr, &val_out, sizeof val_out);
+            data_ptr += sizeof val_out;
+        }
+    } else if (state->cdi_dispatch.format == OUTPUT_16BIT_4_TO_5) {
+        // buffers for encoding
+        int32_t vals_in[4];
+        uint16_t vals_out[5];
+
+        for (int i = 0; i < state->cdi_dispatch.Nfreq; i++) {
+            if (i > 0 && i % 4 == 0) {
+                // we accumulated 4 values in vals_in;
+                // now we compress them into vals_out and copy to CDI buffer
+                encode_4_into_5(vals_in, vals_out);
+                memcpy(data_ptr, vals_out, sizeof vals_out);
+                data_ptr += sizeof vals_out;
+            }
+            vals_in[i % 4] = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, state->base.Navg2_shift, state->base.averaging_mode, ddr_ptr_high);
+        }
+    } else {
+        cdi_not_implemented("data format not supported");
     }
 
     // we don't want to do this ,since the incoming data are still compared
     // against this. Instead, we will zero it in df_transfer
     //memset(ddr_ptr, 0, state.state->cdi_dispatch.Nfreq * sizeof(uint32_t));
-    *crc_ptr = CRC(cdi_ptr, data_size);
+
+    *crc_ptr = CRC(data_start_ptr, data_size);
     cdi_dispatch_uC(&(state->cdi_stats),state->cdi_dispatch.appId, packet_size);
 }
-
-
-void dispatch_16bit_10_plus_6_data(struct core_state* state) {
-    // if we are in tick, we are copyng over TOCK, otherwise TICK !!
-    const void* ddr_ptr = spectra_read_buffer(state->tick_tock);
-    const uint32_t* ddr_ptr_high = spectra_read_buffer_high(state->tick_tock);
-    int offset = state->cdi_dispatch.prod_count * NCHANNELS;
-
-    char* crc_ptr;
-    char* data_ptr;
-    write_packet_id(state->cdi_dispatch.packet_id, &data_ptr, &crc_ptr);
-    char* const data_start_ptr = data_ptr;
-
-    uint32_t data_size = state->cdi_dispatch.Nfreq * sizeof(uint16_t);
-    uint32_t packet_size = data_size + 2 * sizeof(int32_t);
-
-    wait_for_cdi_ready();
-
-    uint16_t val_out;
-    int32_t val_in;
-
-    for (int i = 0; i < state->cdi_dispatch.Nfreq; i++) {
-        val_in = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, state->base.Navg2_shift, state->base.averaging_mode, ddr_ptr_high);
-        val_out = encode_10plus6(val_in);
-        memcpy(data_ptr, &val_out, sizeof val_out);
-        data_ptr += sizeof val_out;
-    }
-
-    // compute CRC
-    uint32_t crc = CRC(data_start_ptr, data_size);
-    memcpy(crc_ptr, &crc, sizeof(crc));
-
-    cdi_dispatch_uC(&(state->cdi_stats),state->cdi_dispatch.appId, packet_size);
-}
-
-
-void dispatch_16bit_updates_data() {
-    cdi_not_implemented("16bit w updates data format");
-}
-
-void dispatch_16bit_float1_data() {
-    cdi_not_implemented("16bit w float1 data format");
-}
-
-void dispatch_16bit_shared_lz_data() {
-    cdi_not_implemented("16bit shared LZ format");
-}
-
-void dispatch_16bit_4_to_5_data(struct core_state* state) {
-    // if we are in tick, we are copyng over TOCK, otherwise TICK !!
-    const void* ddr_ptr = spectra_read_buffer(state->tick_tock);
-    const uint32_t* ddr_ptr_high = spectra_read_buffer_high(state->tick_tock);
-    int offset = state->cdi_dispatch.prod_count * NCHANNELS;
-
-    char* crc_ptr;
-    char* data_ptr;
-    write_packet_id(state->cdi_dispatch.packet_id, &data_ptr, &crc_ptr);
-    // save pointer to the beginning of actual data, to compute its CRC
-    char* const data_start_ptr = data_ptr;
-
-    uint32_t data_size = state->cdi_dispatch.Nfreq * 5 * sizeof(uint16_t) / 4;
-    uint32_t packet_size = data_size + 2 * sizeof(int32_t);
-    wait_for_cdi_ready();
-
-    // buffers for encoding
-    int32_t vals_in[4];
-    uint16_t vals_out[5];
-
-    for (int i = 0; i < state->cdi_dispatch.Nfreq; i++) {
-        if (i > 0 && i % 4 == 0) {
-            // we accumulated 4 values in vals_in;
-            // now we compress them into vals_out and copy to CDI buffer
-            encode_4_into_5(vals_in, vals_out);
-            memcpy(data_ptr, vals_out, sizeof vals_out);
-            data_ptr += sizeof vals_out;
-        }
-        vals_in[i % 4] = get_averaged_value(ddr_ptr, offset, i, state->cdi_dispatch.Navgf, state->base.Navg2_shift, state->base.averaging_mode, ddr_ptr_high);
-    }
-
-    // compute CRC
-    uint32_t crc = CRC(data_start_ptr, data_size);
-    memcpy(crc_ptr, &crc, sizeof(crc));
-
-    cdi_dispatch_uC(&(state->cdi_stats),state->cdi_dispatch.appId, packet_size);
-}
-
 
 void dispatch_grimm_data(struct core_state *state) {
-
-
     // if we are in tick, we are copyng over TOCK, otherwise TICK !!
     const void* ddr_ptr = grimm_spectra_read_buffer(state->tick_tock);
     uint16_t data_size = NSPECTRA * 10 * get_Navg2(state); // we pack 4 int32_t into 5 int16_t
@@ -174,8 +142,6 @@ void dispatch_grimm_data(struct core_state *state) {
     memcpy(cdi_ptr, ddr_ptr, data_size);
     cdi_dispatch_uC(&(state->cdi_stats),AppID_SpectraGrimm, data_size + sizeof(int32_t));
 }
-
-
 
 // send NSPECTRA packets
 void dispatch_tr_data(struct core_state* state) {
@@ -298,9 +264,11 @@ bool delayed_cdi_dispatch_done (struct core_state* state) {
             state->cdi_dispatch.grimm_count >= 1 &&
             state->cdi_dispatch.cal_count >= NCALPACKETS);
 }
+
+
 bool process_delayed_cdi_dispatch (struct core_state* state) {
 
-    // if we are waiting, let's prevent anyone else to send stuff untill we are done
+    // if we are waiting, let's prevent anyone else to send stuff until we are done
     if (state->timing.cdi_dispatch_counter > tap_counter) return true;
 
     // we always send 16 products + maybe some time resolved + maybe grimm
@@ -317,30 +285,7 @@ bool process_delayed_cdi_dispatch (struct core_state* state) {
     if (state->cdi_dispatch.prod_count < NSPECTRA) {
         if (state->base.corr_products_mask & (1<<state->cdi_dispatch.prod_count)) {
             debug_print(".");
-
-            switch (state->cdi_dispatch.format) {
-                case OUTPUT_32BIT:
-                    dispatch_32bit_data(state);
-                    break;
-                case OUTPUT_16BIT_UPDATES:
-                    dispatch_16bit_updates_data();
-                    break;
-                case OUTPUT_16BIT_FLOAT1:
-                    dispatch_16bit_float1_data();
-                    break;
-                case OUTPUT_16BIT_10_PLUS_6:
-                    dispatch_16bit_10_plus_6_data(state);
-                    break;
-                case OUTPUT_16BIT_4_TO_5:
-                    dispatch_16bit_4_to_5_data(state);
-                    break;
-                case OUTPUT_16BIT_SHARED_LZ:
-                    dispatch_16bit_shared_lz_data();
-                    break;
-                default:
-                    cdi_not_implemented("Unsupported output format");
-                    break;
-            }
+            dispatch_data(state);
         }
         state->cdi_dispatch.appId++;
         state->cdi_dispatch.prod_count++;
@@ -383,4 +328,3 @@ bool process_delayed_cdi_dispatch (struct core_state* state) {
     state->timing.cdi_dispatch_counter = tap_counter + state->dispatch_delay;
     return true;
 }
-

--- a/src/interface_utils.c
+++ b/src/interface_utils.c
@@ -1,5 +1,10 @@
+#include <stdlib.h>
+#include <stdint.h>
+
 #include "core_loop.h"
 #include "interface_utils.h"
+
+#include "LuSEE_IO.h"
 
 char user_spectrum_filename[2048];
 
@@ -43,7 +48,7 @@ int read_dynamic_array(const char* fname, int32_t** data)
         return 0;
     }
 
-    fprintf(stdout, "Reading %d entries from file: %s\n", size, fname);
+    fprintf(stderr, "Reading %d entries from file: %s\n", size, fname);
 
     if (size % NCHANNELS) {
         fprintf(stderr, "Error: size %d is not a multiple of NCHANELS=%d, will truncate\n", size, NCHANNELS);

--- a/src/interface_utils.c
+++ b/src/interface_utils.c
@@ -1,6 +1,7 @@
 #include "core_loop.h"
 #include "interface_utils.h"
 
+char user_spectrum_filename[2048];
 
 double generate_gaussian_variate() {
     double u1 = rand() / (double)RAND_MAX;
@@ -13,7 +14,7 @@ void read_array_uint(const char* fname, uint32_t* data, int size)
 {
     FILE* file = fopen(fname, "r");
     if (file == NULL) {
-        printf("Error opening file: %s\n", data);
+        printf("Error opening file: %s\n", fname);
         return;
     }
     for (int i = 0; i < size; i++) {
@@ -26,11 +27,59 @@ void read_array_uint(const char* fname, uint32_t* data, int size)
     fclose(file);
 }
 
+int read_dynamic_array(const char* fname, int32_t** data)
+{
+    FILE* file = fopen(fname, "r");
+    if (file == NULL) {
+        fprintf(stderr, "Error opening file: %s\n", fname);
+        return 0;
+    }
+
+    // read size from first line
+    int size = 0;
+    if (fscanf(file, "%i", &size) != 1) {
+        fprintf(stderr, "Error reading size from file: %s\n", fname);
+        fclose(file);
+        return 0;
+    }
+
+    fprintf(stdout, "Reading %d entries from file: %s\n", size, fname);
+
+    if (size % NCHANNELS) {
+        fprintf(stderr, "Error: size %d is not a multiple of NCHANELS=%d, will truncate\n", size, NCHANNELS);
+        size = (size / NCHANNELS) * NCHANNELS;
+    }
+
+    *data = malloc(size * sizeof(int32_t));
+
+    for(int i =0; i < size/ (NCHANNELS*NSPECTRA); i++) {
+        fprintf(stderr, "read_dynamic_array: group %d address = %p\n", i, (void*)(*data + i*NCHANNELS*NSPECTRA));
+    }
+
+    for (int i = 0; i < size; i++) {
+        int32_t val;
+        if (fscanf(file, "%d", &val) != 1) {
+            fprintf(stderr, "Error reading entry %d from file: %s\n", i, fname);
+            break;
+        }
+        if (i < 4) {
+            fprintf(stderr, "read_dynamic_array: Entry %d: %d\n", i, val);
+        }
+        (*data)[i] = val;
+    }
+
+    fprintf(stderr, "Read %d entries from file: %s\n", size, fname);
+
+    fclose(file);
+    return size;
+}
+
+
 void read_array_int(const char* fname, int32_t* data, int size)
 {
     FILE* file = fopen(fname, "r");
     if (file == NULL) {
-        printf("Error opening file: %s\n", data);
+        printf("Error opening file: %s\n", fname);
         return;
     }
     for (int i = 0; i < size; i++) {
@@ -47,7 +96,7 @@ void read_array_double(const char* fname, double* data, int size)
 {
     FILE* file = fopen(fname, "r");
     if (file == NULL) {
-        printf("Error opening file: %s\n", data);
+        fprintf(stderr, "Error opening file: %s\n", fname);
         return;
     }
     for (int i = 0; i < size; i++) {

--- a/src/interface_utils.c
+++ b/src/interface_utils.c
@@ -57,18 +57,11 @@ int read_dynamic_array(const char* fname, int32_t** data)
 
     *data = malloc(size * sizeof(int32_t));
 
-    for(int i =0; i < size/ (NCHANNELS*NSPECTRA); i++) {
-        fprintf(stderr, "read_dynamic_array: group %d address = %p\n", i, (void*)(*data + i*NCHANNELS*NSPECTRA));
-    }
-
     for (int i = 0; i < size; i++) {
         int32_t val;
         if (fscanf(file, "%d", &val) != 1) {
             fprintf(stderr, "Error reading entry %d from file: %s\n", i, fname);
             break;
-        }
-        if (i < 4) {
-            fprintf(stderr, "read_dynamic_array: Entry %d: %d\n", i, val);
         }
         (*data)[i] = val;
     }

--- a/src/interface_utils.h
+++ b/src/interface_utils.h
@@ -7,9 +7,17 @@
 #include <math.h>
 #include <time.h>
 
+// read size entries from fname into data array
 void read_array_uint(const char* fname, uint32_t* data, int size);
 void read_array_int(const char* fname, int32_t* data, int size);
 void read_array_double(const char* fname, double* data, int size);
+
+// read number of entries from the 1st line of fname
+// allocate memory for data
+// return number of entries
+int read_dynamic_array(const char* fname, int32_t** data);
+
+extern char user_spectrum_filename[2048];
 
 double generate_gaussian_variate();
 

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,8 @@
 #include "cdi_options.h"
 #include "main.h"
 
+#include "interface_utils.h"
+
 enum cmd_format cdi_format = CMD_FILE;
 struct cdi_dtype cdi_in;
 struct cdi_dtype cdi_out;
@@ -23,12 +25,14 @@ int main(int argc, char *argv[]) {
     cdi_in.port = DEFAULT_PORT_IN;
     cdi_out.port = DEFAULT_PORT_OUT;
     cdi_format = CMD_FILE;
+
+    strcpy(user_spectrum_filename, "");
     
     int opt;
-    while ((opt = getopt(argc, argv, "hm:i:o:")) != -1) {
+    while ((opt = getopt(argc, argv, "hm:i:o:s:")) != -1) {
         switch (opt) {
             case 'h':
-                fprintf(stdout, "Usage: %s -m [\"file\" | \"port\"] -i [input file/port] -o [output file/port]\n", argv[0]);
+                fprintf(stdout, "Usage: %s -m [\"file\" | \"port\"] -i [input file/port] -o [output file/port] -s spectrum_file\n", argv[0]);
                 exit(EXIT_SUCCESS);
             case 'm':
                 if (!strcmp(optarg, "file") || !strcmp(optarg, "f")) {
@@ -47,6 +51,10 @@ int main(int argc, char *argv[]) {
             case 'o':
                 strcpy(cdi_out.file, optarg);
                 cdi_out.port = atoi(cdi_out.file); // try to convert to in, don't worry if it fails
+                break;
+            case 's':
+                fprintf(stderr, "Reading spectrum from %s\n", optarg);
+                strcpy(user_spectrum_filename, optarg);
                 break;
             default:
                 raiseError("", argv);

--- a/src/spectrometer_interface.c
+++ b/src/spectrometer_interface.c
@@ -122,7 +122,6 @@ bool spec_new_spectrum_ready() {
 
         if (user_spectrum_size) {
             int offset = call_idx * NCHANNELS * NSPECTRA;
-            // fprintf(stderr, "call_idx = %d, offset = %d, memcpy src = %p\n", call_idx, offset, (void*)(user_spectrum + offset));
             memcpy(SPEC_BUF_INT32, user_spectrum + offset, NCHANNELS * NSPECTRA * sizeof(int32_t));
             // fprintf(stderr, "Using user spectrum number %d, offset = %d, sp[0] = %d, sp[1] = %d, sp[2] = %d, sp[3] = %d, sp[4] = %d, sp[5] = %d, sp[6] = %d, sp[7] = %d, sp[8] = %d, sp[9] = %d \n", call_idx, offset, SPEC_BUF_INT32[0], SPEC_BUF_INT32[1], SPEC_BUF_INT32[2], SPEC_BUF_INT32[3], SPEC_BUF_INT32[4], SPEC_BUF_INT32[5], SPEC_BUF_INT32[6], SPEC_BUF_INT32[7], SPEC_BUF_INT32[8], SPEC_BUF_INT32[9]);
             call_idx = (call_idx + 1) % (user_spectrum_size / (NCHANNELS * NSPECTRA));

--- a/src/spectrometer_interface.c
+++ b/src/spectrometer_interface.c
@@ -10,6 +10,8 @@
 #include <time.h>
 #include "LuSEE_IO.h"
 #include <stdbool.h>
+#include <string.h>
+
 #include "core_loop.h" // for tap_counter
 #include "interface_utils.h"
 
@@ -17,6 +19,8 @@ const char* true_spectrum_filename = CORELOOP_ROOT "/data/true_spectrum.dat";
 uint32_t true_spectrum[NCHANNELS*NSPECTRA];
 const char* ramp_spectrum_filename = CORELOOP_ROOT "/data/ramp_spectrum.dat";
 double ramp_spectrum[NCHANNELS];
+int32_t* user_spectrum = NULL;
+int32_t user_spectrum_size = 0;
 struct timespec time_spec_start;
 
 
@@ -46,6 +50,10 @@ const int ch_ant2[] = {0,1,2,3, 1,1,  2,2,  3,3,  2,2,  3,3, 3, 3};
 void spectrometer_pre_init() {
     read_array_uint(true_spectrum_filename, true_spectrum, NCHANNELS * NSPECTRA);
     read_array_double(ramp_spectrum_filename, ramp_spectrum, NCHANNELS);
+
+    if (strlen(user_spectrum_filename)) {
+        user_spectrum_size = read_dynamic_array(user_spectrum_filename, &user_spectrum);
+    }
 
     SPEC_BUF = malloc(NCHANNELS*NSPECTRA*sizeof(int32_t));
     adc_trigger = false;
@@ -84,15 +92,20 @@ void spec_set_spectrometer_enable(bool on) {
 
 
 bool spec_new_spectrum_ready() {
+    static int call_idx = 0;
     df_flag = false;
+
     if (!spectrometer_enable) {
         return false;
     }
+
+
     clock_gettime(CLOCK_REALTIME, &time_now);
     long ns_passed = (time_now.tv_sec - time_spec_start.tv_sec) * 1e9 + time_now.tv_nsec - time_spec_start.tv_nsec;
     long topass = (long)(floor((4096/102.4e6)*1e9*Navg1));
     //printf ("%li %li \n",ns_passed,topass);
     if (ns_passed > topass) {
+        // fprintf(stderr, "is_ramp: %d, ADC_mode = %d, user_spectrum_size = %d\n", ADC_mode == ADC_RAMP, ADC_mode, user_spectrum_size);
         time_spec_start = time_now;
         df_flag = true;
         int32_t* SPEC_BUF_INT32 = (int32_t*)SPEC_BUF;    
@@ -106,6 +119,19 @@ bool spec_new_spectrum_ready() {
             }
             return true;
         }
+
+        if (user_spectrum_size) {
+            int offset = call_idx * NCHANNELS * NSPECTRA;
+            // fprintf(stderr, "call_idx = %d, offset = %d, memcpy src = %p\n", call_idx, offset, (void*)(user_spectrum + offset));
+            memcpy(SPEC_BUF_INT32, user_spectrum + offset, NCHANNELS * NSPECTRA * sizeof(int32_t));
+            // fprintf(stderr, "Using user spectrum number %d, offset = %d, sp[0] = %d, sp[1] = %d, sp[2] = %d, sp[3] = %d, sp[4] = %d, sp[5] = %d, sp[6] = %d, sp[7] = %d, sp[8] = %d, sp[9] = %d \n", call_idx, offset, SPEC_BUF_INT32[0], SPEC_BUF_INT32[1], SPEC_BUF_INT32[2], SPEC_BUF_INT32[3], SPEC_BUF_INT32[4], SPEC_BUF_INT32[5], SPEC_BUF_INT32[6], SPEC_BUF_INT32[7], SPEC_BUF_INT32[8], SPEC_BUF_INT32[9]);
+            call_idx = (call_idx + 1) % (user_spectrum_size / (NCHANNELS * NSPECTRA));
+
+
+
+            return true;
+        }
+
         for (int i = 0; i < NSPECTRA; i++) {
             for (int j = 0; j < NCHANNELS; j++) {
                 int32_t spec = true_spectrum[i*NCHANNELS+j];
@@ -126,7 +152,8 @@ bool spec_new_spectrum_ready() {
                 SPEC_BUF_INT32[i*NCHANNELS+j] = spec;
             }
         }
-    return true;
+
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
- fix bug in 4-to-5 encoding (last 4 bins were not written)
- fix bugs in rejection (wrong arithmetic)
- fix bugs in final averaging over frequency bins (assignment instead of +=, precompute shift once outside)
- refactor dispatching code to avoid code duplication
- remove dead code
- edit reading user-defined spectrum (arbitrary length, looped over) to increase output predictability