### PR TITLE
Fix bug in commanding.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The version history (changelog) is found [here](documentation/CHANGELOG.md).
 
 Note that each version needs to be compiled with `LuSEE_MiV` of the same version.
 
-## Note on version 0x308:
+## Note on versions 0x308, 0x309:
 
-In general, the version commited and tagged in github contains a matching version in `coreloop.h`. Version 0x308 is an exception, since it is 0x307 + documentation and code comments. So coreloop.h version in this case still says 0x307.
+In general, the version commited and tagged in github contains a matching version in `coreloop.h`. Version 0x308 is an exception, since it is 0x307 + documentation and code comments. Version 0x309 is also an exception, since it fixes a single bug. So coreloop.h version in this case still says 0x307.
 
 # Code documentation
 

--- a/coreloop/commanding.c
+++ b/coreloop/commanding.c
@@ -74,7 +74,7 @@ bool process_cdi(struct core_state* state)
         } else if (cmd==RFS_SETTINGS)  {
             uint16_t cmd_end = (state->cmd_end + 1) % CMD_BUFFER_SIZE;
             if (cmd_end == state->cmd_ptr) {
-                state->base.errors != CDI_COMMAND_BUFFER_OVERFLOW;
+                state->base.errors |= CDI_COMMAND_BUFFER_OVERFLOW;
                 cmd_end = state->cmd_end;
                 return false;
             } else {
@@ -348,7 +348,7 @@ bool process_cdi(struct core_state* state)
         case RFS_SET_BITSLICE_AUTO:
             if ((arg_low > 0) && (arg_low < 64)) {
                 for (int i=0; i<NSPECTRA; i++) state->base.bitslice[i] = 0xFF;
-                state->base.bitslice_keep_bits = arg_low;                
+                state->base.bitslice_keep_bits = arg_low;
             } else {
                 state->base.errors |= CDI_COMMAND_BAD_ARGS;
             }
@@ -495,7 +495,7 @@ bool process_cdi(struct core_state* state)
             }
             break;
 
-        case RFS_SET_GRIMMS_TALES:            
+        case RFS_SET_GRIMMS_TALES:
             state->base.grimm_enable = arg_low;
             break;
 
@@ -512,7 +512,7 @@ bool process_cdi(struct core_state* state)
             else
                 state->grimm_weights[state->grimm_weight_ndx] = 0x100;
             break;
-            
+
         // CALIBRATOR SECTION
         case RFS_SET_CAL_ENABLE:
             if (arg_low<0xFF) {
@@ -534,7 +534,7 @@ bool process_cdi(struct core_state* state)
             break;
 
         case RFS_SET_CAL_DRIFT_GUARD:
-            state->cal.drift_guard = arg_low*20;            
+            state->cal.drift_guard = arg_low*20;
             break;
 
         case RFS_SET_CAL_DRIFT_STEP:
@@ -590,7 +590,7 @@ bool process_cdi(struct core_state* state)
             // and does not seem to work either
             //if (arg_low == 0xff)
             //   calib_set_weight(state->cal.weight_ndx, 0x100);
-            //else                     
+            //else
             calib_set_weight(state->cal.weight_ndx, arg_low);
             state->cal.weight_ndx++;
             break;
@@ -602,13 +602,13 @@ bool process_cdi(struct core_state* state)
         case RFS_SET_CAL_PFB_NDX_LO:
             state->cal.pfb_index = arg_low + (state->cal.pfb_index & 0xFF00);
             calib_set_PFB_index(state->cal.pfb_index);
-            state->cal.zoom_avg_idx = -1; 
+            state->cal.zoom_avg_idx = -1;
             break;
 
         case RFS_SET_CAL_PFB_NDX_HI:
             state->cal.pfb_index = ((arg_low & 0x07) << 8) + (state->cal.pfb_index & 0x00FF);
             calib_set_PFB_index(state->cal.pfb_index);
-            state->cal.zoom_avg_idx = -1; 
+            state->cal.zoom_avg_idx = -1;
             break;
 
         case RFS_SET_CAL_BITSLICE: {
@@ -637,7 +637,7 @@ bool process_cdi(struct core_state* state)
             }
             break;
 
-        case RFS_SET_CAL_BITSLICE_AUTO: 
+        case RFS_SET_CAL_BITSLICE_AUTO:
             state->cal.auto_slice = arg_low;
             break;
 
@@ -667,7 +667,7 @@ bool process_cdi(struct core_state* state)
                 state->base.errors |= CDI_COMMAND_BAD_ARGS;
             }
             break;
-        
+
         case RFS_SET_CAL_SNR_RATIO:
             state->cal.SNR_minratio = arg_low;
             break;
@@ -688,9 +688,9 @@ bool process_cdi(struct core_state* state)
             break;
 
         case RFS_SET_ZOOM_RANGE:
-            state->cal.zoom_ndx_range = MIN(arg_low + (arg_low*arg_low)/32, 2048); 
+            state->cal.zoom_ndx_range = MIN(arg_low + (arg_low*arg_low)/32, 2048);
             break;
-        
+
         case RFS_SET_ZOOM_DIFF:
             state->cal.zoom_diff_1 = (arg_low & 0b01) != 0;
             state->cal.zoom_diff_2 = (arg_low & 0b10) != 0;
@@ -711,7 +711,7 @@ bool process_cdi(struct core_state* state)
 
         case RFS_SET_REGION_INFO:
             if (state->region_have_lock) {
-                flash_send_region_info(state); 
+                flash_send_region_info(state);
             } else {
                 state->base.errors |= CDI_COMMAND_BAD_ARGS;
             }

--- a/coreloop/spectrometer_interface.h
+++ b/coreloop/spectrometer_interface.h
@@ -9,28 +9,10 @@
 
 #define NCHANNELS 2048
 #define NSPECTRA 16
-#define NCALPACKETS 16 
+#define NCALPACKETS 16
 #define NSPECTRA_AUTO 4
 #define NINPUT 4
 #define UINT14_MAX 16384
-
-// for bit slicing
-#define bit_select_A1   0x1F
-#define bit_select_A2   0x1F
-#define bit_select A3   0x1F
-#define bit_select_A4   0x1F
-#define bit_select_X12R 0x1F
-#define bit_select_X12I 0x1F
-#define bit_select_X13R 0x1F
-#define bit_select_X13I 0x1F
-#define bit_select_X14R 0x1F
-#define bit_select_X14I 0x1F
-#define bit_select_X23R 0x1F
-#define bit_select_X23I 0x1F
-#define bit_select_X24R 0x1F
-#define bit_select_X24I 0x1F
-#define bit_select_X34R 0x1F
-#define bit_select_X34I 0x1F
 
 #define WD_TICKS_PER_S (102400000)
 
@@ -123,7 +105,7 @@ void spec_set_avg1 (uint8_t Navg1_shift);
 void spec_set_bitslice(uint8_t *bitslice);
 
 // fires up the ADC statistic engine
-void spec_trigger_ADC_stat(uint16_t Nsamples); 
+void spec_trigger_ADC_stat(uint16_t Nsamples);
 // If we have ADC results, return true and get ADC level statistics into 4 element array in order to enable automatic gain, etc
 bool spec_get_ADC_stat(struct ADC_stat *stat);
 
@@ -134,7 +116,7 @@ void spec_get_time(uint32_t *time_sec, uint16_t *time_subsec);
 bool spec_new_spectrum_ready();
 
 // return true if DF dropped spectra
-bool spec_df_dropped(); 
+bool spec_df_dropped();
 
 // clears the DF flag
 void spec_clear_df_flag();

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+### Version 3r09
+ * Remove unused bit_select definitions from spectrometer_interface.h
+ * Fix bug in commanding.c (!= instead of |= on command buffer overflow)
+ 
 ### Version 3r08
  * This is a documented and commented version of 0x307.
  * Functionally it should be identical to 0x307, but we did a version bump for sanity


### PR DESCRIPTION
On command buffer overflow, the error bit was not set, because of the != instead of |=.
Unlikely to be triggered.
Also removed dead code (unused bit_select #defines from spectrometer_interface.h.